### PR TITLE
Make V and W initialization more general

### DIFF
--- a/src/orbit_dynamics.jl
+++ b/src/orbit_dynamics.jl
@@ -121,8 +121,8 @@ function spherical_harmonic_gravity(r::Array{<:Real, 1}, coef::Array{<:Real, 2},
     z0    = r_ref * r[3] / r_sqr
 
     # Initialize Intermediary Matrices
-    V = zeros(Float64, n_max+2, n_max+2)
-    W = zeros(Float64, n_max+2, n_max+2)
+    V = zeros(eltype(r), n_max+2, n_max+2)
+    W = zeros(eltype(r), n_max+2, n_max+2)
 
     # Calculate zonal terms V(n, 0). Set W(n,0)=0.0
     V[0+1, 0+1] = r_ref /sqrt(r_sqr)


### PR DESCRIPTION
Changed V and W to initialize as the same type as r. This helps with ForwardDiff which is trying to convert dual numbers into float64 otherwise