### PR TITLE
Update documentation to reflect Epoch class

### DIFF
--- a/src/time.jl
+++ b/src/time.jl
@@ -234,7 +234,7 @@ epc = Epoch("2018-12-01 16:22:19.123456789 GPS")
 ```
 """
 struct Epoch
-    # All days, seconds, and nanoseconds are stored internally in the TAI time scale, conversion to from TAI is done on intpu/output interacting.
+    # All days, seconds, and nanoseconds are stored internally in the TAI time scale, conversion to from TAI is done on intput/output interacting.
     days::Int # Total days [0, ∞)
     seconds::Int # Integer seconds [0, 86400)
     nanoseconds::Float64 # Fractional seconds [0, 1)

--- a/src/time.jl
+++ b/src/time.jl
@@ -209,11 +209,11 @@ interpreted as an offset in seconds to add to the Epoch.
 The class also supports all arithmetic operators: `==`, `!=`, `<`, `<=`, `>`, `>=`
 
 Arguments:
-- `year::Int` Year
-- `month::Int` Month
-- `day::Int` Day
-- `hour::Int` Hour (optional)
-- `minute::Int` Minute (optional)
+- `year::Real` Year
+- `month::Real` Month
+- `day::Real` Day
+- `hour::Real` Hour (optional)
+- `minute::Real` Minute (optional)
 - `second::Real` Seconds (optional)
 - `nanoseconds::Real` Nanoseconds (optional)
 - `tsys::String`: Time system of the epoch at initialization

--- a/src/time.jl
+++ b/src/time.jl
@@ -234,7 +234,7 @@ epc = Epoch("2018-12-01 16:22:19.123456789 GPS")
 ```
 """
 struct Epoch
-    # All days, seconds, and nanoseconds are stored internally in the TAI time scale, conversion to from TAI is done on intput/output interacting.
+    # All days, seconds, and nanoseconds are stored internally in the TAI time scale, conversion to from TAI is done on input/output interacting.
     days::Int # Total days [0, ∞)
     seconds::Int # Integer seconds [0, 86400)
     nanoseconds::Float64 # Fractional seconds [0, 1)

--- a/src/time.jl
+++ b/src/time.jl
@@ -210,8 +210,8 @@ The class also supports all arithmetic operators: `==`, `!=`, `<`, `<=`, `>`, `>
 
 Arguments:
 - `year::Int` Year
-- `year::Int` Month
-- `year::Int` Day
+- `month::Int` Month
+- `day::Int` Day
 - `hour::Int` Hour (optional)
 - `minute::Int` Minute (optional)
 - `second::Real` Seconds (optional)


### PR DESCRIPTION
Here's how the non string constructor is currently defined:
```python
function Epoch(year::Real, month::Real, day::Real, hour::Real=0, minute::Real=0, 
               second::Real=0, nanosecond::Real=0.0; tsys::String="TAI")
```